### PR TITLE
Add an option to set the queue prefetch limit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,8 @@ export default url => {
 
     channel.assertQueue(consumer.channel);
 
+    if (configOptions.prefetch) channel.prefetch(configOptions.prefetch);
+
     channel.consume(consumer.channel, async msg => {
       if (!msg) return console.warn('empty message received');
 


### PR DESCRIPTION
This allows you the ability to control the number of messages a consumer gets at a time.